### PR TITLE
Fixed for tables with deleted rows and 9.3 version support

### DIFF
--- a/lib/fromZip.js
+++ b/lib/fromZip.js
@@ -2,6 +2,7 @@
 var JSZip = require('jszip');
 var toArray = require('./util').toArray;
 var read = require('./read');
+var parseFields = require('./fields');
 var Promise = require('lie');
 module.exports = function(buffer) {
   return new Promise(function(yes) {
@@ -9,13 +10,25 @@ module.exports = function(buffer) {
     var unzippedFiles = zip.file(/a0{1,7}(?:[^2-8]|[190a-z]|(?:[1-9a-z]+[0-9a-z]+))\.(?:gdbtable|gdbtablx)/);
     var tableA = {};
     var tablxA = {};
-    unzippedFiles.forEach(function(file) {
-      if (file.name.slice(-9) === '.gdbtable' && (parseInt(file.name.slice(-17, -9), 16) === 1 || parseInt(file.name.slice(-17, -9), 16) > 8)) {
-        tableA[parseInt(file.name.slice(-17, -9), 16)] = file;
-      } else if (file.name.slice(-9) === '.gdbtablx' && (parseInt(file.name.slice(-17, -9), 16) === 1 || parseInt(file.name.slice(-17, -9), 16) > 8)) {
-        tablxA[parseInt(file.name.slice(-17, -9), 16)] = file;
-      }
-    });
+    
+    var magic_number = 8; //assume > version 9.3
+
+		var sys_catalog_table = unzippedFiles.find(file => (file.name.slice(-9) === ".gdbtable" && parseInt(file.name.slice(-17, - 9), 16) === 1));
+
+		var fieldInfo = parseFields(sys_catalog_table.asArrayBuffer());
+		
+		if(fieldInfo.version===3){
+			magic_number = 36; //version 9.3
+		}
+
+		unzippedFiles.forEach(function(file) {
+			if (file.name.slice(-9) === ".gdbtable" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > magic_number)) {
+				tableA[parseInt(file.name.slice(-17, - 9), 16)] = file;
+			}
+			else if (file.name.slice(-9) === ".gdbtablx" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > magic_number)) {
+				tablxA[parseInt(file.name.slice(-17, - 9), 16)] = file;
+			}
+		});
     var table = toArray(tableA);
     var tablx = toArray(tablxA);
     function readFile(num) {

--- a/lib/fromZip.js
+++ b/lib/fromZip.js
@@ -11,24 +11,24 @@ module.exports = function(buffer) {
     var tableA = {};
     var tablxA = {};
     
-    var magic_number = 8; //assume > version 9.3
+    var minSysTableNum = 8; //assume > version 9.3
 
-		var sys_catalog_table = unzippedFiles.find(file => (file.name.slice(-9) === ".gdbtable" && parseInt(file.name.slice(-17, - 9), 16) === 1));
+    var sysCatalogTable = unzippedFiles.find(file => (file.name.slice(-9) === ".gdbtable" && parseInt(file.name.slice(-17, - 9), 16) === 1));
 
-		var fieldInfo = parseFields(sys_catalog_table.asArrayBuffer());
+    var fieldInfo = parseFields(sysCatalogTable.asArrayBuffer());
 		
-		if(fieldInfo.version===3){
-			magic_number = 36; //version 9.3
-		}
+    if(fieldInfo.version===3){
+	minSysTableNum = 36; //version 9.3
+    }
 
-		unzippedFiles.forEach(function(file) {
-			if (file.name.slice(-9) === ".gdbtable" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > magic_number)) {
-				tableA[parseInt(file.name.slice(-17, - 9), 16)] = file;
-			}
-			else if (file.name.slice(-9) === ".gdbtablx" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > magic_number)) {
-				tablxA[parseInt(file.name.slice(-17, - 9), 16)] = file;
-			}
-		});
+    unzippedFiles.forEach(function(file) {
+	if (file.name.slice(-9) === ".gdbtable" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > minSysTableNum)) {
+		tableA[parseInt(file.name.slice(-17, - 9), 16)] = file;
+	}
+	else if (file.name.slice(-9) === ".gdbtablx" && (parseInt(file.name.slice(-17, - 9), 16) === 1 || parseInt(file.name.slice(-17, - 9), 16) > minSysTableNum)) {
+		tablxA[parseInt(file.name.slice(-17, - 9), 16)] = file;
+	}
+    });
     var table = toArray(tableA);
     var tablx = toArray(tablxA);
     function readFile(num) {

--- a/lib/rows.js
+++ b/lib/rows.js
@@ -68,7 +68,7 @@ var dataTypes = [
 
 module.exports = function(buffer, bufferx){
   var fieldInfo = parseFields(buffer);
-  var rowOffsets = tablex(bufferx);
+  var rowOffsets = tablex(buffer, bufferx);
   var out = rowOffsets.map(function(offset){
       //console.log('row',i);
       if(!offset){

--- a/lib/tablex.js
+++ b/lib/tablex.js
@@ -1,13 +1,14 @@
 'use strict';
-module.exports = function (buffer){
-  var data = new DataView(buffer);
-  var offset = 8;
+module.exports = function (buffer, bufferx){
+  var tbl_num_rows = (new DataView(buffer)).getUint32(4,true);
+  var data = new DataView(bufferx);
   var rows = [];
-  var len = data.getUint32(offset, true);
-  offset += 8;//yes 8
+  var offset = 16;
   var i = 0;
-  while(i < len){
-    rows[i++] = data.getUint32(offset, true);
+  while(i<tbl_num_rows){
+    var val = data.getUint32(offset,true);
+    if(val==0){offset += 5;continue;}
+    rows[i++] = val;
     offset += 5;//yes 5
   }
   return rows;

--- a/lib/tablex.js
+++ b/lib/tablex.js
@@ -1,14 +1,13 @@
 'use strict';
 module.exports = function (buffer, bufferx){
-  var tbl_num_rows = (new DataView(buffer)).getUint32(4,true);
+  var tblNumRows = new DataView(buffer).getUint32(4, true);
   var data = new DataView(bufferx);
   var rows = [];
   var offset = 16;
   var i = 0;
-  while(i<tbl_num_rows){
+  while(i<tblNumRows){
     var val = data.getUint32(offset,true);
-    if(val==0){offset += 5;continue;}
-    rows[i++] = val;
+    if(val!==0){rows[i++] = val;}
     offset += 5;//yes 5
   }
   return rows;


### PR DESCRIPTION
So... the library wasn't parsing some filegdbs for me, here is an example (sorry, it's big)
http://www.fs.fed.us/r6/data-library/gis/okanogan/documents/Transportation.zip

I discovered that the number of records in the tablex function would sometimes return incorrect numbers (deleted rows(?)); to get the real number of rows in a table, you have to get it from the gdbtable.

Here is an example from Evan:
tablex number of rows:
https://github.com/rouault/dump_gdbtable/blob/master/dump_gdbtable.py#L171

table number of rows:
https://github.com/rouault/dump_gdbtable/blob/master/dump_gdbtable.py#L179

The code in this PR passes the gdbtable buffer into the rows function and then gets the numrows, but it could also parse the numrows first and pass that int val in...however you want to implement...
